### PR TITLE
build-sys: fix installing the includes

### DIFF
--- a/libgcab/meson.build
+++ b/libgcab/meson.build
@@ -9,7 +9,7 @@ enums = gnome.mkenums(
   c_template : 'gcab-enums.c.etemplate',
   h_template : 'gcab-enums.h.etemplate',
   install_header : true,
-  install_dir : 'include/libgcab-1.0/libgcab',
+  install_dir : join_paths(get_option('includedir'), 'libgcab-1.0/libgcab'),
   symbol_prefix : 'gcab',
   identifier_prefix : 'GCab',
 )


### PR DESCRIPTION
Without this patch `meson --includedir=/usr/x86_64-pc-linux-gnu/include` doesn't work, it still installs the headers to /usr/include (or prefix/include).