### PR TITLE
nls: Add meson option to enable/disable NLS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -118,8 +118,11 @@ configure_file(
 )
 
 subdir('libgcab')
-subdir('po')
 subdir('src')
+
+if get_option('nls')
+subdir('po')
+endif
 
 if get_option('docs')
 subdir('docs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('docs', type : 'boolean', value : true, description : 'enable developer documentation')
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
+option('nls', type : 'boolean', value : true, description : 'enable native language support')
 option('tests', type : 'boolean', value : true, description : 'enable tests')


### PR DESCRIPTION
New meson option to enable/disable Native Language Support.
See https://packages.gentoo.org/useflags/nls for motivation.